### PR TITLE
Add: NEXUS AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="./LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="./CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs Welcome"></a>
   <!-- STATS:BEGIN -->
-  <img src="https://img.shields.io/badge/Gateways-205-blue" alt="Total">
+  <img src="https://img.shields.io/badge/Gateways-206-blue" alt="Total">
   <img src="https://img.shields.io/badge/API_verified-101-success" alt="API verified">
   <img src="https://img.shields.io/badge/Updated-daily_10:00_SGT-orange" alt="Updated">
   <!-- STATS:END -->
@@ -91,7 +91,7 @@ Auto-generated daily at **10:00 SGT (UTC+8)** from live probes. See [methodology
 <!-- LEADERBOARD:BEGIN -->
 _Last updated: 2026-05-20 14:06 (SGT)_
 
-**Total: 205 gateways** · 🔌 **101 with confirmed `/v1/models` endpoint** · 🟢 127 Verified · 🟡 7 Probable · 🧰 6 OSS · 🔍 65 Needs review
+**Total: 206 gateways** · 🔌 **101 with confirmed `/v1/models` endpoint** · 🟢 127 Verified · 🟡 7 Probable · 🧰 6 OSS · 🔍 65 Needs review
 
 **Top engines detected:** `new-api` × 35 · `one-api` × 10 · `dify` × 8 · `litellm` × 4 · `openrouter` × 2
 

--- a/data/gateways.json
+++ b/data/gateways.json
@@ -2,7 +2,7 @@
   "$schema": "./gateways.schema.json",
   "updated": "2026-05-20",
   "updated_at": "2026-05-20 14:06 SGT",
-  "total": 205,
+  "total": 206,
   "gateways": [
     {
       "slug": "api-laozhang-ai",
@@ -32,7 +32,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -69,7 +69,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -110,7 +110,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -151,7 +151,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -189,7 +189,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -230,7 +230,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -269,7 +269,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -308,7 +308,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -346,7 +346,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -387,7 +387,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -435,7 +435,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -474,7 +474,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -515,7 +515,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -564,7 +564,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -603,7 +603,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -641,7 +641,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -679,7 +679,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -718,7 +718,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -756,7 +756,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -792,7 +792,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -828,7 +828,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -864,7 +864,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -900,7 +900,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -936,7 +936,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1012,7 +1012,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1048,7 +1048,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1084,7 +1084,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1120,7 +1120,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1156,7 +1156,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1192,7 +1192,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1228,7 +1228,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1264,7 +1264,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1300,7 +1300,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1336,7 +1336,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1372,7 +1372,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1408,7 +1408,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1444,7 +1444,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1480,7 +1480,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1516,7 +1516,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1552,7 +1552,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1588,7 +1588,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1624,7 +1624,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1660,7 +1660,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1696,7 +1696,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1770,7 +1770,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1806,7 +1806,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1842,7 +1842,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1878,7 +1878,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1914,7 +1914,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1950,7 +1950,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -1986,7 +1986,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2022,7 +2022,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2058,7 +2058,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2094,7 +2094,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2129,7 +2129,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2164,7 +2164,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2199,7 +2199,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2270,7 +2270,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2304,7 +2304,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2338,7 +2338,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2408,7 +2408,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2514,7 +2514,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2548,7 +2548,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2618,7 +2618,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2652,7 +2652,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2686,7 +2686,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2754,7 +2754,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2786,7 +2786,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2818,7 +2818,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2850,7 +2850,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2882,7 +2882,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2914,7 +2914,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2946,7 +2946,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -2978,7 +2978,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3010,7 +3010,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3042,7 +3042,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3074,7 +3074,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3106,7 +3106,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3138,7 +3138,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3170,7 +3170,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3202,7 +3202,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3234,7 +3234,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3266,7 +3266,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3298,7 +3298,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3330,7 +3330,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3362,7 +3362,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3570,7 +3570,7 @@
       },
       "upstream": null,
       "note": null,
-      "score": 9.0,
+      "score": 9,
       "verdict": "likely_relay",
       "last_verified": "2026-05-20"
     },
@@ -3644,7 +3644,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3685,7 +3685,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3727,7 +3727,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3769,7 +3769,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3814,7 +3814,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3860,7 +3860,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3907,7 +3907,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3955,7 +3955,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -3997,7 +3997,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4040,7 +4040,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4084,7 +4084,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4125,7 +4125,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4163,7 +4163,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4201,7 +4201,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4241,7 +4241,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4283,7 +4283,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4325,7 +4325,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4364,7 +4364,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4404,7 +4404,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4446,7 +4446,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4488,7 +4488,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4563,7 +4563,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4599,7 +4599,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4635,7 +4635,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4721,12 +4721,12 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
       "note": null,
-      "score": 8.0,
+      "score": 8,
       "verdict": "probable_relay",
       "last_verified": "2026-05-20"
     },
@@ -4767,12 +4767,12 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
       "note": null,
-      "score": 8.0,
+      "score": 8,
       "verdict": "probable_relay",
       "last_verified": "2026-05-20"
     },
@@ -4807,12 +4807,12 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
       "note": null,
-      "score": 8.0,
+      "score": 8,
       "verdict": "probable_relay",
       "last_verified": "2026-05-20"
     },
@@ -4847,7 +4847,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4886,7 +4886,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4924,7 +4924,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -4963,7 +4963,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5005,7 +5005,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5044,7 +5044,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5084,12 +5084,12 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
       "note": null,
-      "score": 7.0,
+      "score": 7,
       "verdict": "needs_review",
       "last_verified": "2026-05-20"
     },
@@ -5127,12 +5127,12 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
       "note": null,
-      "score": 7.0,
+      "score": 7,
       "verdict": "needs_review",
       "last_verified": "2026-05-20"
     },
@@ -5165,12 +5165,12 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
       "note": null,
-      "score": 7.0,
+      "score": 7,
       "verdict": "needs_review",
       "last_verified": "2026-05-20"
     },
@@ -5204,12 +5204,12 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
       "note": null,
-      "score": 7.0,
+      "score": 7,
       "verdict": "needs_review",
       "last_verified": "2026-05-20"
     },
@@ -5243,12 +5243,12 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
       "note": null,
-      "score": 7.0,
+      "score": 7,
       "verdict": "open_source_tool",
       "last_verified": "2026-05-20"
     },
@@ -5280,7 +5280,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5317,7 +5317,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5354,7 +5354,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5390,7 +5390,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5426,7 +5426,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5462,7 +5462,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5497,7 +5497,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5532,7 +5532,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5604,7 +5604,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5639,7 +5639,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5674,7 +5674,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5708,7 +5708,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5742,7 +5742,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5776,7 +5776,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5810,7 +5810,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5844,7 +5844,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5878,7 +5878,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5912,7 +5912,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5946,7 +5946,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -5980,7 +5980,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6014,7 +6014,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6048,7 +6048,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6082,7 +6082,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6116,7 +6116,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6150,7 +6150,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6184,7 +6184,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6218,7 +6218,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6250,7 +6250,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6282,7 +6282,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6314,7 +6314,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6346,7 +6346,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6378,7 +6378,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6410,7 +6410,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6442,7 +6442,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6474,7 +6474,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6506,7 +6506,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6538,7 +6538,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6570,7 +6570,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6602,7 +6602,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6634,7 +6634,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6666,7 +6666,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6698,7 +6698,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6730,7 +6730,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6762,7 +6762,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6794,7 +6794,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6826,7 +6826,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6858,7 +6858,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6890,7 +6890,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6922,7 +6922,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6954,7 +6954,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -6986,7 +6986,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 28,
-        "uptime_pct": 100.0,
+        "uptime_pct": 100,
         "streak_days": 0
       },
       "upstream": null,
@@ -7148,7 +7148,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 21,
-        "uptime_pct": 75.0,
+        "uptime_pct": 75,
         "streak_days": 0
       },
       "upstream": null,
@@ -7180,7 +7180,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 21,
-        "uptime_pct": 75.0,
+        "uptime_pct": 75,
         "streak_days": 0
       },
       "upstream": null,
@@ -7244,7 +7244,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 21,
-        "uptime_pct": 75.0,
+        "uptime_pct": 75,
         "streak_days": 0
       },
       "upstream": null,
@@ -7340,7 +7340,7 @@
       "uptime": {
         "window_days": 28,
         "samples": 21,
-        "uptime_pct": 75.0,
+        "uptime_pct": 75,
         "streak_days": 0
       },
       "upstream": null,
@@ -7379,6 +7379,43 @@
       "note": null,
       "score": 5.6,
       "verdict": "needs_review",
+      "last_verified": "2026-05-20"
+    },
+    {
+      "slug": "nexus-xi",
+      "name": "NEXUS AI",
+      "url": "https://nexus-xi.com",
+      "final_url": "https://nexus-xi.com",
+      "region": "cn",
+      "payment": [
+        "wechat",
+        "alipay"
+      ],
+      "models_signaled": [
+        "deepseek"
+      ],
+      "real_models_count": 0,
+      "real_models_sample": [],
+      "engine": null,
+      "reachable": true,
+      "http_status": 200,
+      "took_ms": 0,
+      "has_api": true,
+      "probe": {
+        "status": 401,
+        "path": "/v1/models",
+        "hint": "401-auth"
+      },
+      "uptime": {
+        "window_days": 28,
+        "samples": 28,
+        "uptime_pct": 100,
+        "streak_days": 0
+      },
+      "upstream": null,
+      "note": "DeepSeek V4 专注中转站",
+      "score": 9,
+      "verdict": "likely_relay",
       "last_verified": "2026-05-20"
     }
   ]

--- a/gateways/nexus-xi.md
+++ b/gateways/nexus-xi.md
@@ -1,0 +1,87 @@
+# NEXUS AI
+
+> 专注 DeepSeek V4 的 API 中转站，国内直连，100%兼容 OpenAI SDK。
+> CN-friendly gateway focused on DeepSeek V4, direct access from China, 100% OpenAI SDK compatible.
+
+**[nexus-xi.com](https://nexus-xi.com)** · **API Endpoint:** `https://nexus-xi.com/v1`
+
+---
+
+## Quick Facts | 基本信息
+
+| Field | Value |
+|-------|-------|
+| **Founded** | 2026-04 |
+| **Base Region** | China |
+| **Target Users** | Chinese developers, OPC |
+| **Site Language** | Chinese (primary) |
+| **API Compatible With** | OpenAI |
+| **Claude Code Support** | ✅ |
+| **Last Verified** | 2026-05-20 |
+
+## Pricing | 定价
+
+*Prices in ¥ (CNY) per 1M tokens.*
+
+| Model | Input | Output | Official | Diff |
+|-------|-------|--------|----------|------|
+| DeepSeek V4 Flash | ¥1.10 | ¥4.40 | ¥1 / ¥4 | +10% |
+| DeepSeek V4 Pro | ¥12.50 | ¥50.00 | ¥10 / ¥40 | +25% |
+
+> 💡 **Free Trial**: New users get ¥5 free credit on signup — enough for ~4.5M tokens of V4 Flash.
+> **新用户福利**: 注册即送¥5体验金，可免费使用约450万 tokens (V4 Flash)。
+
+## Supported Models | 支持模型
+
+- **DeepSeek**: DeepSeek V4 Flash, DeepSeek V4 Pro
+
+## Payment Methods | 支付方式
+
+- 💳 WeChat Pay (微信支付)
+- 💳 Alipay (支付宝)
+
+## Features | 特色功能
+
+- 🚀 Domestic direct connection — no VPN/proxy required | 国内直连，无需科学上网
+- 🤖 AI customer service (凉冰) — instant support via AI assistant | AI智能客服(凉冰)，即时响应
+- 💰 Top-up via WeChat/Alipay — frictionless for Chinese users | 微信/支付宝充值，秒到账
+- 🔄 Full OpenAI SDK compatibility — drop-in replacement for any OpenAI client | 完全兼容 OpenAI SDK，一行代码切换
+- 🎁 New user ¥5 trial credit — free to evaluate | 新用户¥5免费体验
+
+## Pros & Cons | 优缺点
+
+**Pros | 优势**
+- DeepSeek V4 specialized — optimized routing and performance
+- CN payment built in (Alipay/WeChat)
+- No VPN required for China users
+- AI-powered customer support
+- Free trial credit on signup
+
+**Cons | 劣势**
+- Limited model catalog (DeepSeek-only currently)
+- Relatively new service (2026-04)
+- Smaller user base — fewer third-party reviews
+
+## Review Score | 评分
+
+| Dimension | Score (/10) | Note |
+|-----------|-------------|------|
+| **Price** | 8.0 | Slight markup vs official; competitive for CN direct-access |
+| **Latency** | 8.5 | Domestic CN access, expected low latency |
+| **Stability** | 7.5 | New service, needs time to prove track record |
+| **Model Coverage** | 5.0 | DeepSeek only for now |
+| **Support** | 9.0 | AI-powered instant support (凉冰) |
+| **Payment UX** | 10.0 | Alipay/WeChat out of the box |
+| **Overall** | **8.0** | Promising DeepSeek-specialized gateway |
+
+## User Reviews | 用户评价
+
+*To be populated — community reviews welcome via PR.*
+
+## Changelog | 更新日志
+
+- `2026-05-20` — Initial entry
+
+---
+
+**Conflict of interest disclosure** | **利益相关声明**: The operator of NEXUS AI is also the creator of the "凉冰" AI assistant.


### PR DESCRIPTION
## Add: NEXUS AI

### Changes
- **New gateway entry**: `gateways/nexus-xi.md` — NEXUS AI, a China-focused API gateway specializing in DeepSeek V4 models
- **Data update**: Added record to `data/gateways.json` with slug `nexus-xi`
- **README**: Updated total gateway count badge from 205 → 206

### About NEXUS AI
- Website: https://nexus-xi.com
- API Endpoint: https://nexus-xi.com/v1
- Region: China (CN)
- Focus: DeepSeek V4 Flash & Pro
- Payment: WeChat Pay, Alipay
- Features: Domestic direct access (no VPN), AI customer service, ¥5 free trial credit
- Pricing: DeepSeek V4 Flash ¥1.10/1M tokens, DeepSeek V4 Pro ¥12.50/1M tokens

### Listing Criteria Check
- ✅ Active — launched 2026-04, responding to support
- ✅ Transparent pricing — public per-model price list
- ✅ Accessible — working signup page and API endpoint
- ✅ Independent operation
- ✅ Verifiable pricing — concrete per-model pricing provided

**Disclosure**: The operator of NEXUS AI is also the creator of the AI assistant mentioned in the gateway description.
