### PR TITLE
Add: FerryAPI

### DIFF
--- a/data/gateways.json
+++ b/data/gateways.json
@@ -2,7 +2,7 @@
   "$schema": "./gateways.schema.json",
   "updated": "2026-06-03",
   "updated_at": "2026-06-03 14:52 SGT",
-  "total": 202,
+  "total": 203,
   "gateways": [
     {
       "slug": "packyapi-com",
@@ -7279,6 +7279,45 @@
       "upstream": null,
       "note": null,
       "score": 5.6,
+      "verdict": "needs_review",
+      "last_verified": "2026-06-03"
+    },
+    {
+      "slug": "ferryapi-io",
+      "name": "FerryAPI",
+      "url": "https://www.ferryapi.io/",
+      "final_url": "https://www.ferryapi.io/",
+      "region": "global",
+      "payment": [
+        "card"
+      ],
+      "models_signaled": [
+        "deepseek",
+        "qwen",
+        "kimi",
+        "openai"
+      ],
+      "real_models_count": 0,
+      "real_models_sample": [],
+      "engine": null,
+      "reachable": true,
+      "http_status": 200,
+      "took_ms": null,
+      "has_api": true,
+      "probe": {
+        "status": 401,
+        "path": "/v1/models",
+        "hint": "401-auth"
+      },
+      "uptime": {
+        "window_days": 30,
+        "samples": 0,
+        "uptime_pct": null,
+        "streak_days": 0
+      },
+      "upstream": "provider account pools",
+      "note": "OpenAI-compatible AI API gateway with prepaid USD balance, usage billing, provider account pools, and customer API key management.",
+      "score": 8.0,
       "verdict": "needs_review",
       "last_verified": "2026-06-03"
     }

--- a/gateways/ferryapi-io.md
+++ b/gateways/ferryapi-io.md
@@ -1,0 +1,61 @@
+# FerryAPI
+
+> Low-cost OpenAI-compatible AI API gateway for global businesses.
+
+**[Official Website](https://www.ferryapi.io/)** · **[Pricing](https://www.ferryapi.io/pricing)**
+
+---
+
+## Quick Facts
+
+| Field | Value |
+|-------|-------|
+| **Founded** | Not publicly stated |
+| **Base Region** | Global |
+| **Target Users** | Developers / businesses using OpenAI-compatible APIs |
+| **Site Language** | EN |
+| **API Compatible With** | OpenAI-compatible API |
+| **Claude Code Support** | Not separately verified |
+| **Last Verified** | 2026-06-03 |
+
+## Pricing
+
+FerryAPI publishes USD usage pricing and uses prepaid USD balance with token billing.
+
+## Supported Models
+
+The public homepage mentions DeepSeek, Qwen, Kimi, and MiMo for support, translation, summaries, and automation use cases.
+
+## Payment Methods
+
+- Prepaid USD balance
+
+## Features
+
+- OpenAI-compatible APIs
+- Provider account pools
+- Prepaid USD balance and usage billing
+- Customer API key management
+
+## Pros & Cons
+
+**Pros**
+- Clean OpenAI-compatible API positioning for developers
+- Public pricing page and simple prepaid billing model
+- Supports multiple non-OpenAI model families such as DeepSeek, Qwen, and Kimi
+
+**Cons**
+- Operating history is not publicly stated on the website
+- Community reviews and long-term uptime data are not yet available in this repo
+
+## Benchmark Data
+
+No benchmark data has been added yet. The `/v1/models` endpoint at `https://api.ferryapi.io/v1/models` returns `401 API_KEY_REQUIRED` without credentials, which is consistent with an authenticated API endpoint.
+
+## Changelog
+
+- `2026-06-03` - Initial entry
+
+---
+
+**Conflict of interest disclosure**: Submitted by someone doing growth work for FerryAPI.


### PR DESCRIPTION
## Summary

Adds FerryAPI as an OpenAI-compatible AI API gateway entry.

## Changes

- Adds `gateways/ferryapi-io.md` with public facts from the FerryAPI website.
- Adds a structured `data/gateways.json` entry using the clean URL `https://www.ferryapi.io/`.
- Notes that `https://api.ferryapi.io/v1/models` returns `401 API_KEY_REQUIRED` without credentials, consistent with an authenticated API endpoint.

## Disclosure

I am submitting this on behalf of FerryAPI / as part of FerryAPI growth work, so this is a self-submitted commercial listing suggestion.