### PR TITLE
Add Prism API candidate

### DIFF
--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -378,3 +378,6 @@ https://www.openai-labs.com
 https://xeduapi.com
 https://zen-ai.top
 https://www.hvoy.ai
+
+# ============ Community submissions: Prism API / 558686.xyz ============
+https://sub2api.558686.xyz


### PR DESCRIPTION
## Summary
- Add Prism API / 558686.xyz as a candidate gateway URL for the daily probe pipeline.

## Disclosure
This is a community/operator-side submission. I am not editing the generated leaderboard directly; the candidate is intended to be validated by the repository's normal reachability and /v1/models probe workflow.

## Service notes
- Public app: https://sub2api.558686.xyz/home
- API base: https://sub2api.558686.xyz/v1
- Independent sub2api-based OpenAI-compatible gateway for overseas developers.
- Supports GPT, Claude, Gemini, and Antigravity model families.
- Crypto-friendly recharge/voucher options.
- Not for Mainland China users.

## Verification
- Product page is live through https://558686.xyz / https://sub2api.558686.xyz/home.
- API base /v1/models returns an auth-protected response, so the endpoint is reachable for the probe workflow.