### PR TITLE
Add: AIFast Hub (www.aifast.club)

### DIFF
--- a/data/gateways.json
+++ b/data/gateways.json
@@ -11,8 +11,7 @@
       "final_url": "https://www.aifast.club",
       "region": "cn",
       "payment": [
-        "alipay",
-        "wechat"
+        "crypto"
       ],
       "models_signaled": [
         "claude",
@@ -56,7 +55,8 @@
       "note": "OpenAI-compatible endpoint. Check the current marketplace and maintenance notices for model availability.",
       "score": null,
       "verdict": "likely_relay",
-      "last_verified": "2026-07-12"
+      "last_verified": "2026-07-12",
+      "payment_note": "International users: crypto only. 1 AIFast balance dollar (1 刀) = 0.07 USDC or 0.07 USDT; check supported network in console."
     },
     {
       "slug": "packyapi-com",

--- a/data/gateways.json
+++ b/data/gateways.json
@@ -45,9 +45,9 @@
       "took_ms": null,
       "has_api": true,
       "probe": {
-        "status": 200,
+        "status": 401,
         "path": "/v1/models",
-        "hint": "openai-models-json"
+        "hint": "authentication-required-json"
       },
       "uptime": null,
       "upstream": null,

--- a/data/gateways.json
+++ b/data/gateways.json
@@ -24,7 +24,6 @@
         "kimi"
       ],
       "real_models_count": null,
-      "real_models_count_note": "See the current AIFast marketplace catalog; configured entries do not guarantee current availability.",
       "real_models_sample": [
         "gpt-5.6-sol",
         "gpt-5.6-terra",
@@ -52,11 +51,10 @@
       },
       "uptime": null,
       "upstream": null,
-      "note": "OpenAI-compatible endpoint. Check the current marketplace and maintenance notices for model availability.",
+      "note": "OpenAI-compatible endpoint. International users: crypto only; 1 AIFast balance dollar (1 刀) = 0.07 USDC or 0.07 USDT. Check model availability, supported network and deposit instructions in the current console.",
       "score": null,
       "verdict": "likely_relay",
-      "last_verified": "2026-07-12",
-      "payment_note": "International users: crypto only. 1 AIFast balance dollar (1 刀) = 0.07 USDC or 0.07 USDT; check supported network in console."
+      "last_verified": "2026-07-12"
     },
     {
       "slug": "packyapi-com",

--- a/data/gateways.json
+++ b/data/gateways.json
@@ -5,6 +5,60 @@
   "total": 204,
   "gateways": [
     {
+      "slug": "aifast-club",
+      "name": "AI快站 · AIFast Hub",
+      "url": "https://www.aifast.club",
+      "final_url": "https://www.aifast.club",
+      "region": "cn",
+      "payment": [
+        "alipay",
+        "wechat"
+      ],
+      "models_signaled": [
+        "claude",
+        "gpt",
+        "gemini",
+        "deepseek",
+        "qwen",
+        "grok",
+        "glm",
+        "kimi"
+      ],
+      "real_models_count": null,
+      "real_models_count_note": "See the current AIFast marketplace catalog; configured entries do not guarantee current availability.",
+      "real_models_sample": [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "claude-sonnet-5",
+        "claude-opus-4-8",
+        "grok-4.5",
+        "grok-4-20-reasoning",
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+        "gemini-3.5-flash",
+        "qwen3.7-max",
+        "glm-5.2",
+        "kimi-k2.7-code"
+      ],
+      "engine": null,
+      "reachable": true,
+      "http_status": 200,
+      "took_ms": null,
+      "has_api": true,
+      "probe": {
+        "status": 200,
+        "path": "/v1/models",
+        "hint": "openai-models-json"
+      },
+      "uptime": null,
+      "upstream": null,
+      "note": "OpenAI-compatible endpoint. Check the current marketplace and maintenance notices for model availability.",
+      "score": null,
+      "verdict": "likely_relay",
+      "last_verified": "2026-07-12"
+    },
+    {
       "slug": "packyapi-com",
       "name": "PackyAPI (PackyCode)",
       "url": "https://www.packyapi.com",

--- a/gateways/aifast-club.md
+++ b/gateways/aifast-club.md
@@ -49,6 +49,15 @@ curl https://www.aifast.club/v1/chat/completions \
 
 Model support, latency and availability vary with the provider, route, account, network and maintenance state. Test the exact model and request format before production use.
 
+## International payment
+
+International users can pay **only with cryptocurrency**. The current balance conversion is:
+
+- **1 USD-denominated balance unit = 0.07 USDC**
+- **1 USD-denominated balance unit = 0.07 USDT**
+
+Fiat payment methods are not available to international users. Check the AIFast console before payment because the supported network or deposit instructions can change.
+
 ## Notes | 说明
 
 - This entry does not publish a fixed model count because configuration entries do not equal currently available models.

--- a/gateways/aifast-club.md
+++ b/gateways/aifast-club.md
@@ -53,8 +53,7 @@ Model support, latency and availability vary with the provider, route, account, 
 
 International users can pay **only with cryptocurrency**. The current balance conversion is:
 
-- **1 USD-denominated balance unit = 0.07 USDC**
-- **1 USD-denominated balance unit = 0.07 USDT**
+- **1 AIFast balance dollar ("1 刀") = 0.07 USDC or 0.07 USDT**
 
 Fiat payment methods are not available to international users. Check the AIFast console before payment because the supported network or deposit instructions can change.
 

--- a/gateways/aifast-club.md
+++ b/gateways/aifast-club.md
@@ -1,0 +1,57 @@
+# AI快站 · AIFast Hub (www.aifast.club)
+
+> OpenAI-compatible AI API gateway for developers who want to use models from several providers through one endpoint. The current catalog and maintenance status are available on the platform.
+
+**[Website](https://www.aifast.club)** · **[Published status reference](https://kkwang4444.github.io/api-status/)** · **[Integration guide](https://github.com/KKWANG4444/ai-api-proxy-china-guide)**
+
+---
+
+## Quick facts | 基本信息
+
+| Field | Value |
+|---|---|
+| **Region** | China-oriented service |
+| **Site language** | Chinese |
+| **API style** | OpenAI-compatible endpoint |
+| **Base URL** | `https://www.aifast.club/v1` |
+| **Model availability** | Check the current marketplace and latest maintenance notices |
+| **Last reviewed** | 2026-07-12 |
+
+## Current model examples | 当前模型示例
+
+The following IDs were checked against the AIFast public model configuration. A configured ID may still be temporarily unavailable during maintenance.
+
+- **OpenAI**: `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`
+- **Anthropic**: `claude-sonnet-5`, `claude-opus-4-8`, `claude-fable-5`
+- **xAI**: `grok-4.5`, `grok-4.3`, `grok-4-20-reasoning`
+- **Google**: `gemini-3.5-flash`
+- **DeepSeek**: `deepseek-v4-pro`, `deepseek-v4-flash`
+- **Alibaba**: `qwen3.7-max`
+- **Zhipu**: `glm-5.2`
+- **ByteDance**: `doubao-seed-2-1-pro-260628`
+- **Moonshot**: `kimi-k2.7-code`
+
+Doubao Seed 2.1 Turbo is not presented as currently available because the latest AIFast notice says it is temporarily offline for maintenance.
+
+## API example | API 示例
+
+```bash
+curl https://www.aifast.club/v1/chat/completions \
+  -H "Authorization: Bearer $AIFAST_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.6-terra",
+    "messages": [
+      {"role": "user", "content": "Hello"}
+    ]
+  }'
+```
+
+Model support, latency and availability vary with the provider, route, account, network and maintenance state. Test the exact model and request format before production use.
+
+## Notes | 说明
+
+- This entry does not publish a fixed model count because configuration entries do not equal currently available models.
+- It does not quote model prices. Pricing and account options should be checked in the AIFast console.
+- The linked status project contains published observations, not an uptime guarantee or SLA.
+- The submitter operates AIFast; this conflict of interest is disclosed in the pull request.

--- a/gateways/aifast-club.md
+++ b/gateways/aifast-club.md
@@ -51,9 +51,9 @@ Model support, latency and availability vary with the provider, route, account, 
 
 ## International payment
 
-International users can pay **only with cryptocurrency**. The current balance conversion is:
+International users can pay **only with cryptocurrency**. **1 AIFast balance dollar ("1 刀") = 0.07 USDC or 0.07 USDT.**
 
-- **1 AIFast balance dollar ("1 刀") = 0.07 USDC or 0.07 USDT**
+This is an AIFast balance-unit conversion, not a token market exchange rate or an official model price.
 
 Fiat payment methods are not available to international users. Check the AIFast console before payment because the supported network or deposit instructions can change.
 


### PR DESCRIPTION
## Add: AIFast Hub (www.aifast.club)

This PR adds [www.aifast.club](https://www.aifast.club), an OpenAI-compatible AI API gateway.

The entry uses a durable catalog reference instead of a fixed model count. Example IDs were checked against the public AIFast model configuration, while availability is explicitly tied to the current marketplace and maintenance notices.

### International payment

International users can pay only with cryptocurrency. The current conversion is **1 AIFast balance dollar ("1 刀") = 0.07 USDC or 0.07 USDT**. Fiat payment is not available to international users. The supported network and deposit instructions must be checked in the AIFast console before payment. This is an AIFast balance-unit conversion. It is not a token market exchange rate, and it is not an official model price.

### Validation

- Unauthenticated `GET /v1/models` returns a JSON `401` authentication-required response, confirming the documented API route without exposing catalog data.
- The AIFast record does not claim a fixed latency, SLA, uptime percentage, score, or currently available model total.
- Payment metadata is `crypto` for international users.
- Base URL: `https://www.aifast.club/v1`.

### Disclosure

I operate AIFast and am submitting my own service. Please review the entry under the repository's normal inclusion criteria.
