### PR TITLE
添加 cocodot(支付宝直充 · 官转 · 支持 Claude Code 直连 · 可验真)

### DIFF
--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -378,3 +378,4 @@ https://www.openai-labs.com
 https://xeduapi.com
 https://zen-ai.top
 https://www.hvoy.ai
+https://cocodot.co


### PR DESCRIPTION
添加 cocodot(https://cocodot.co):

- 支付宝人民币充值,按量计费,封顶不超官网价(主流模型官网9折起)
- 海外注册公司运营,走持牌云厂商官转(非逆向)
- OpenAI 兼容 + Anthropic 兼容端点(Claude Code 可直连,beta)
- 开源工具 LLMprobe 可自测模型不降智,方法公开:https://cocodot.co/trust

感谢维护这份清单!