### PR TITLE
添加 cocodot(支付宝直充 · 官转 · 支持 Claude Code 直连 · 可验真)

### DIFF
--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -378,3 +378,4 @@ https://www.openai-labs.com
 https://xeduapi.com
 https://zen-ai.top
 https://www.hvoy.ai
+https://cocodot.co


### PR DESCRIPTION
按本列表格式补充一条:**cocodot**(https://cocodot.co)——OpenAI/Anthropic 兼容中转,一个 Key 调 Claude/GPT/Gemini/DeepSeek;支付宝人民币直充、按量计费;主打不降智,可用开源工具 LLMprobe 自行验证(实测 87/100)。

利益相关声明:本 PR 由 cocodot 团队提交;无返佣/推广链接,信息均来自官网,欢迎核验调整。