### PR TITLE
Add: AI Router

### DIFF
--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -78,6 +78,7 @@ https://claudecn.top
 https://www.openclaudecode.cn
 https://api.timebackward.com
 https://codesome.ai
+https://ai-router.dev
 https://infai.cc
 https://doro.lol
 https://cubence.com

--- a/data/sites.yaml
+++ b/data/sites.yaml
@@ -65,6 +65,11 @@ openrouter.ai:
   region: "global"
   note: "Pioneer of the multi-provider aggregation pattern."
 
+ai-router.dev:
+  name: "AI Router"
+  region: "global"
+  note: "OpenAI-compatible ChatGPT API relay for developers; public gateway endpoint at api.ai-router.dev/v1."
+
 github.com/songquanpeng/one-api:
   name: "One API (open-source)"
   region: "self-hosted"


### PR DESCRIPTION
Adds AI Router as a new gateway candidate for automated validation and classification.

What this PR does:
- adds `https://ai-router.dev` to `data/candidates.txt`
- adds a minimal `data/sites.yaml` override for display name and region

Why it fits:
- OpenAI-compatible ChatGPT API relay
- public site and API endpoint
- user-facing API keys, usage visibility, and pricing flow

Disclosure: operator self-submission.