### PR TITLE
data: add cocodot.co to candidates.txt

### DIFF
--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -378,3 +378,4 @@ https://www.openai-labs.com
 https://xeduapi.com
 https://zen-ai.top
 https://www.hvoy.ai
+https://cocodot.co


### PR DESCRIPTION
One line added to `data/candidates.txt` so the daily `validate_candidates.py` pass can probe and classify it the same way as every other entry — nothing here asks you to make a judgement call.

**Why a PR instead of another issue:** #18 has been open since 2026-07-08. I'd rather not add a third issue to the pile — this is the mechanical path, and if the automated probe decides it doesn't qualify, that outcome is fine.

**Disclosure:** I'm affiliated with cocodot. No referral or tracking links — the entry is the plain domain, and whatever your probe reports is what should stand. Feel free to close this if you'd prefer to keep candidate submissions issue-only.