### PR TITLE
Add: XiuRouter

### DIFF
--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -378,3 +378,6 @@ https://www.openai-labs.com
 https://xeduapi.com
 https://zen-ai.top
 https://www.hvoy.ai
+
+# ============ Batch 15: Operator-submitted managed gateways ============
+https://router-api.xiu.ai

--- a/data/sites.yaml
+++ b/data/sites.yaml
@@ -116,3 +116,9 @@ api.daheiai.com:
   name: "大黑 API 导航"
   region: "cn"
   verdict: "directory"
+
+router-api.xiu.ai:
+  name: "XiuRouter"
+  region: "global"
+  verdict: "needs_review"
+  note: "Managed multi-provider model API operated by XiuLab Inc; product, pricing, and docs are published at router.xiu.ai and docs.xiu.ai."


### PR DESCRIPTION
## Summary

- add `https://router-api.xiu.ai` to the managed-gateway candidate probe queue
- add a human-readable `XiuRouter` site override with `global` region and `needs_review` status
- point reviewers to the public product, pricing, and documentation surfaces without adding an operator-authored score

## Verification

- `https://router-api.xiu.ai` returns HTTP 200
- `https://router-api.xiu.ai/v1/models` returns HTTP 401 with a JSON `Invalid token` response when called without an API key, matching the repository probe contract
- `python scripts/selfcheck.py` passes
- YAML parsing and duplicate-candidate checks pass

## Disclosure

This is an operator-affiliated submission for XiuRouter, which is operated by XiuLab Inc. The public console exposes a New API version header; this PR does not present the underlying gateway engine as proprietary. XiuRouter is submitted for independent probing and manual review based on its managed multi-provider service, public per-model pricing, native OpenAI/Anthropic/Gemini-compatible routes, scoped keys, usage records, and Agent integration workflow.

Product: https://router.xiu.ai/  
Pricing: https://router.xiu.ai/en/pricing/  
Docs: https://docs.xiu.ai/router/