### PR TITLE
Add: Bifrost

### DIFF
--- a/data/candidates.txt
+++ b/data/candidates.txt
@@ -318,6 +318,7 @@ https://github.com/QuantumNous/new-api
 https://github.com/berriai/litellm
 https://github.com/Portkey-Ai/gateway
 https://github.com/helicone/helicone
+https://github.com/maximhq/bifrost
 https://github.com/langfuse/langfuse
 https://github.com/langgenius/dify
 https://github.com/VoltAgent/voltagent

--- a/data/sites.yaml
+++ b/data/sites.yaml
@@ -80,6 +80,12 @@ github.com/QuantumNous/new-api:
   region: "self-hosted"
   verdict: "open_source_tool"
 
+github.com/maximhq/bifrost:
+  name: "Bifrost (Maxim AI)"
+  region: "self-hosted"
+  verdict: "open_source_tool"
+  note: "Open-source Go AI gateway with a unified OpenAI-compatible API."
+
 packyapi.com:
   name: "PackyAPI (PackyCode)"
   region: "cn"


### PR DESCRIPTION
## summary

- add the Bifrost GitHub repository to the candidate gateway sources
- classify it as a self-hosted open-source tool in the human-curated overrides
- avoid adding hosted pricing, uptime, or benchmark claims because Bifrost is self-hosted open source

## verification

- git diff --check
- the Bifrost URL is reachable

## disclosure

This is a self-submission from a contributor affiliated with Maxim AI, the organization behind Bifrost.